### PR TITLE
feat(ChatGPT): 別の料理を探す機能を作成

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -7,7 +7,7 @@ import os
 from typing import Union
 import logging
 import uvicorn
-
+from typing import List, Optional
 
 app = FastAPI()
 
@@ -33,21 +33,39 @@ if __name__ == "__main__":
 
 
 # レシピ名を出力
-async def get_recipe_gpt(keywords: str) -> str:
-    prompt = f"'{keywords}' のキーワードに合ったレシピ名を1つ出力してください。 レシピは答えずに1つのレシピ名だけ簡潔に出力してください。 良い例:お好み焼き,  悪い例1:今日のおすすめレシピは、「簡単！お好み焼き」です。,  悪い例2:「簡単！お好み焼き」, 悪い例3:韓国チーズ焼き ビビンバ ミンチカツ ビッグマック(複数のレシピ名は不要、1つだけ)"
-    response = openai.Completion.create(
-        engine="text-davinci-003",
-        prompt=prompt,
-        max_tokens=50,
-        n=1,
-        stop=None,
-        temperature=0.5,
-    )
-    message = response.choices[0].text.strip()
+async def get_recipe_gpt(
+    keywords: str, existingRecipeNames: Optional[List[str]]
+) -> str:
+    # If existing recipes are provided, modify the prompt
+    if existingRecipeNames:
+        # Join the existing recipe names into a string with a comma and space in between each name
+        existing_recipes_string = ", ".join(existingRecipeNames)
+        prompt = f"'{keywords}' のキーワードに合った、以下のレシピ名 '{existing_recipes_string}' に含まれない新しいレシピ名を1つ出力してください。 レシピは答えずに1つのレシピ名だけ簡潔に出力してください。 良い例:お好み焼き,  悪い例1:今日のおすすめレシピは、「簡単！お好み焼き」です。,  悪い例2:「簡単！お好み焼き」, 悪い例3:韓国チーズ焼き ビビンバ ミンチカツ ビッグマック(複数のレシピ名は不要、1つだけ)"
+    else:
+        prompt = f"'{keywords}' のキーワードに合ったレシピ名を1つ出力してください。 レシピは答えずに1つのレシピ名だけ簡潔に出力してください。 良い例:お好み焼き,  悪い例1:今日のおすすめレシピは、「簡単！お好み焼き」です。,  悪い例2:「簡単！お好み焼き」, 悪い例3:韓国チーズ焼き ビビンバ ミンチカツ ビッグマック(複数のレシピ名は不要、1つだけ)"
+
+    while True:
+        response = openai.Completion.create(
+            engine="text-davinci-003",
+            prompt=prompt,
+            max_tokens=50,
+            n=1,
+            stop=None,
+            temperature=0.5,
+        )
+        message = response.choices[0].text.strip()
+
+        # If existing recipes are provided and the generated recipe is not in the list, break the loop
+        if existingRecipeNames and message not in existingRecipeNames:
+            break
+        # If no existing recipes are provided, break the loop
+        elif not existingRecipeNames:
+            break
+
     return message
 
 
-# unsplashの画像検索用にレシピ名をシンプルに & 英語に翻訳
+#  unsplashの画像検索用にレシピ名をシンプルに & 英語に翻訳
 async def translate_recipe_to_english(recipe: str) -> str:
     prompt = f"レシピ名 '{recipe}' を、一般的でシンプルなレシピ名に変換して、半角小文字の英語に翻訳して、出力してください。 変換例1...サーモンと新玉ねぎのカルパッチョ -> carpaccio, 変換例2...こってりとんこつ醤油ラーメン -> ramen, 変換例3...クリームチーズとほうれん草のオムレツ -> omelette 出力例1...carpaccio, 出力例2...ramen, 出力例3...omelette"
     response = openai.Completion.create(
@@ -78,6 +96,7 @@ async def get_recipe_details_gpt(recipe: str) -> Union[str, dict]:
         return "Error: Unable to generate recipe details. Please try again."
 
     recipe_text = response.choices[0].text.strip()
+    print("recipe_text:", recipe_text)  # ログ出力
 
     def extract_list(text, keyword):
         split_text = re.split(f"{keyword}\s*?", text)
@@ -116,14 +135,18 @@ async def get_recipe_details_gpt(recipe: str) -> Union[str, dict]:
         "tips": extract_list(recipe_text, "ポイント:"),
     }
 
+    print("recipe_dict:", recipe_dict)  # ログ出力
+
     logger.info("get_recipe_details_gpt finished")
     return recipe_dict
 
 
 @app.get("/api/recipe")
-async def recipe(keywords: str = Query(None)):
+async def recipe(
+    keywords: str = Query(None), existingRecipeNames: Optional[List[str]] = Query(None)
+):
     try:
-        recommended_recipe = await get_recipe_gpt(keywords)
+        recommended_recipe = await get_recipe_gpt(keywords, existingRecipeNames)
         query_for_unsplash = await translate_recipe_to_english(recommended_recipe)
         recipe_details = await get_recipe_details_gpt(recommended_recipe)
 


### PR DESCRIPTION
## Notion URLとテスト環境URL

- https://www.notion.so/ddb9768ff69b4f36b2192f9cdb6f98a2?v=95db7050e3a9456ab29330becc7ad7c1&p=988d486f9f8f41c081994302585e594c&pm=s

## やったこと

- main.pyに、既出のレシピ名（existingRecipeNames）を引数として受けとった時に、重複しないようにレシピを出力するようにした。
- existingRecipeNamesがないときは今まで通りレシピを出力する
